### PR TITLE
Removed extra curly brace from Collectory entity UID endpoints

### DIFF
--- a/slate/source/localizable/index.html.md
+++ b/slate/source/localizable/index.html.md
@@ -2553,7 +2553,7 @@ Get citations for a list of data resource UIDs
 ### HTTP Request
 `POST <%= I18n.t(:collectoryApiUrl) %>/ws/citations`
 
-## 8.6 GET /ws/{entity}}/{uid}
+## 8.6 GET /ws/{entity}/{uid}
 ```shell
 curl -X 'GET' '<%= I18n.t(:collectoryApiUrl) %>/ws/collection/co139' \
   -H 'accept: application/json'
@@ -2677,7 +2677,7 @@ Parameter | Mandatory | Default | Description
 entity | Y | | The entity name e.g. collection, dataProvider, institution
 uid | N | | The entity uid 
 
-## 8.7 POST /ws/{entity}}/{uid}
+## 8.7 POST /ws/{entity}/{uid}
 ```shell
 curl -X 'POST' '<%= I18n.t(:collectoryApiUrl) %>/ws/dataProvider/dp5249' \
   -H 'accept: application/json' -H "Authorization: Bearer {access_token}" -d 


### PR DESCRIPTION
Removed extra curly braces for the Collectory `/ws/{entity}/{uid}` endpoints

![Screen Shot 2022-09-12 at 11 21 44 am](https://user-images.githubusercontent.com/104949733/189558601-bc73da78-6d0c-44dc-9891-5fc0c21cc553.png)
