### PR TITLE
Feature/locale fix

### DIFF
--- a/cicd/pipeline/build_docs_buildspec.yaml
+++ b/cicd/pipeline/build_docs_buildspec.yaml
@@ -18,6 +18,7 @@ phases:
       # - sudo apt-get update -y
       # - sudo apt install -y ruby ruby-dev build-essential libffi-dev zlib1g-dev liblzma-dev nodejs patch
       # - gem update --system
+      - echo environment $ENVIRONMENT
       - gem install bundler
       - BUNDLE_GEMFILE="$(pwd)/slate/Gemfile" bundle install
   pre_build:

--- a/cicd/pipeline/build_docs_buildspec.yaml
+++ b/cicd/pipeline/build_docs_buildspec.yaml
@@ -18,6 +18,7 @@ phases:
       # - sudo apt-get update -y
       # - sudo apt install -y ruby ruby-dev build-essential libffi-dev zlib1g-dev liblzma-dev nodejs patch
       # - gem update --system
+      - export ENVIRONMENT=staging
       - echo environment $ENVIRONMENT
       - gem install bundler
       - BUNDLE_GEMFILE="$(pwd)/slate/Gemfile" bundle install

--- a/cicd/pipeline/build_docs_buildspec.yaml
+++ b/cicd/pipeline/build_docs_buildspec.yaml
@@ -18,8 +18,6 @@ phases:
       # - sudo apt-get update -y
       # - sudo apt install -y ruby ruby-dev build-essential libffi-dev zlib1g-dev liblzma-dev nodejs patch
       # - gem update --system
-      - export ENVIRONMENT=staging
-      - echo environment $ENVIRONMENT
       - gem install bundler
       - BUNDLE_GEMFILE="$(pwd)/slate/Gemfile" bundle install
   pre_build:

--- a/slate/config.rb
+++ b/slate/config.rb
@@ -41,7 +41,7 @@ set :relative_links, true
 
 set :build_dir, '../build'
 
-activate :i18n, :mount_at_root => :ENV['ENVIRONMENT']
+activate :i18n, :mount_at_root => :staging
 
 # Build Configuration
 configure :build do

--- a/slate/config.rb
+++ b/slate/config.rb
@@ -41,7 +41,7 @@ set :relative_links, true
 
 set :build_dir, '../build'
 
-activate :i18n, :mount_at_root => ENV['ENVIRONMENT']
+activate :i18n, :langs => [ENV['ENVIRONMENT']]
 
 # Build Configuration
 configure :build do

--- a/slate/config.rb
+++ b/slate/config.rb
@@ -41,7 +41,7 @@ set :relative_links, true
 
 set :build_dir, '../build'
 
-activate :i18n, :mount_at_root => :ENV['ENVIRONMENT']
+activate :i18n, :mount_at_root => :ENV.fetch('ENVIRONMENT')
 
 # Build Configuration
 configure :build do

--- a/slate/config.rb
+++ b/slate/config.rb
@@ -41,7 +41,7 @@ set :relative_links, true
 
 set :build_dir, '../build'
 
-activate :i18n, :mount_at_root => :ENV.fetch('ENVIRONMENT')
+activate :i18n, :mount_at_root => ENV['ENVIRONMENT']
 
 # Build Configuration
 configure :build do

--- a/slate/config.rb
+++ b/slate/config.rb
@@ -41,7 +41,7 @@ set :relative_links, true
 
 set :build_dir, '../build'
 
-activate :i18n, :mount_at_root => :staging
+activate :i18n, :mount_at_root => :ENV['ENVIRONMENT']
 
 # Build Configuration
 configure :build do


### PR DESCRIPTION
ensure the correct locale is used that corresponds to the environment .

The i18n directive was changed from :mount_at_root to :langs

:mount_at_root creates files for all existing locales/environments but only copies the specified one to the root. This works when the locale is hard coded in config.rb but I couldn't get it working when the locale is taken from an environment var.

:langs will only create a file for the specified locale, other existing locales are ignored. This worked when using an environment var and I think suits our purposes better as we're using locales as a way to differentiate different deploy environments, we don't really want or need to deploy a production template in the development environment for example