### PR TITLE
Update config from alerts-dev to alerts.test.ala.org.au

### DIFF
--- a/slate/locales/development.yml
+++ b/slate/locales/development.yml
@@ -1,7 +1,7 @@
 ---
 development:
-  alertsAPIUrl: https://api.test.ala.org.au/alerts-dev
-  alertsAppUrl: https://alerts.dev.ala.org.au
+  alertsAPIUrl: https://api.test.ala.org.au/alerts-test
+  alertsAppUrl: https://alerts.test.ala.org.au
   argaAPIUrl: https://staging.arga.org.au/api
   argaAppUrl: https://staging.arga.org.au
   authoriseUrl: https://auth-secure-development.auth.ap-southeast-2.amazoncognito.com/oauth2/authorize

--- a/slate/locales/testing.yml
+++ b/slate/locales/testing.yml
@@ -1,6 +1,6 @@
 ---
 testing:
-  alertsAPIUrl: https://api.test.ala.org.au/alerts-dev
+  alertsAPIUrl: https://api.test.ala.org.au/alerts-test
   alertsAppUrl: https://alerts.test.ala.org.au
   argaAPIUrl: https://staging.arga.org.au/api
   argaAppUrl: https://staging.arga.org.au

--- a/slate/source/openapi/swagger-initializer.js
+++ b/slate/source/openapi/swagger-initializer.js
@@ -4,7 +4,7 @@ window.onload = function() {
     // the following lines will be replaced by docker/configurator, when it runs in a docker-container
     window.ui = SwaggerUIBundle({
       urls: [
-        { name: "alerts", url: "./specs/alerts-dev.json"},
+        { name: "alerts", url: "./specs/alerts.json"},
         { name: "common", url: "./specs/common.json"},
         { name: "data-quality-service", url: "./specs/dqf-service.json"},
         { name: "doi", url: "./specs/doi.json"},


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->